### PR TITLE
Update action-sheet.tsx

### DIFF
--- a/src/components/action-sheet/action-sheet.tsx
+++ b/src/components/action-sheet/action-sheet.tsx
@@ -1,18 +1,14 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, h } from '@stencil/core';
 
-import { Config, actionSheetController } from '@ionic/core';
+import { actionSheetController, getMode } from '@ionic/core';
 
 @Component({
   tag: 'component-action-sheet',
   styleUrl: 'action-sheet.css'
 })
 export class ActionSheet {
-  mode!: string;
-
-  @Prop({ context: 'config' }) config: Config;
-
   open = async () => {
-    const mode = this.config.get('mode');
+    const mode = getMode();
 
     const actionSheet = await actionSheetController.create({
       header: 'Albums',


### PR DESCRIPTION
```@Prop({ context: 'config' }) config: Config;``` is deprecated, replaced with ```getMode``` from @ionic/core as used in ionic **toolbar** and **segment** component.

Updated and works with
**@stencil/core 2.3.0**
**@ionic/core: ^5.5.2**

Ref: [breaking changes](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md)