### PR TITLE
fix(app): prevent text highlighting

### DIFF
--- a/src/components/app-root/app-root.css
+++ b/src/components/app-root/app-root.css
@@ -1,0 +1,3 @@
+ion-app {
+  user-select: none;
+}


### PR DESCRIPTION
Normally, Ionic apps add `user-select: none` when on mobile: https://github.com/ionic-team/ionic-framework/blob/7315e0157b917d2e3586c64f8082026827812943/core/src/components/app/app.scss#L2-L4

However, the kitchen sink demo is meant to *emulate* mobile while not being on a true mobile device. So, when doing things like dragging the sheet modal around, text gets highlighted when it shouldn't.

This PR applies `user-select: none` to the `ion-app` directly to cover all cases.