### PR TITLE
feat(datetime-button): update ionic, add datetime-button demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^6.0.0",
-        "date-fns": "^2.25.0"
+        "@ionic/core": "^6.5.4"
       },
       "devDependencies": {
-        "@stencil/core": "^2.9.0",
+        "@stencil/core": "^2.22.2",
         "@types/jest": "^26.0.24",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -675,12 +674,12 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0.tgz",
-      "integrity": "sha512-3e5EJhDebK4pCiFREpNB95o2kBSAdhRb3eMsBDOCYWYuFlcZEOGOpiGx+kYF/klYVQnB45UXAmR8nCX1indmHQ==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.5.4.tgz",
+      "integrity": "sha512-RHXoFRXOQl5o0COxlFfSfgAK8HZvmZ5Kd/YAORNzTqbm0W/bicUmbJf/oVUpWRnOl+R8sgGBUpOnwhTHl9jTag==",
       "dependencies": {
-        "@stencil/core": "~2.11.0-0",
-        "ionicons": "^6.0.0",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.1.3",
         "tslib": "^2.1.0"
       }
     },
@@ -1004,9 +1003,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.2.tgz",
+      "integrity": "sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -2245,18 +2244,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
-      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -3715,23 +3702,11 @@
       "dev": true
     },
     "node_modules/ionicons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
-      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.1.3.tgz",
+      "integrity": "sha512-ptzz38dd/Yq+PgjhXegh7yhb/SLIk1bvL9vQDtLv1aoSc7alO6mX2DIMgcKYzt9vrNWkRu1f9Jr78zIFFyOXqw==",
       "dependencies": {
-        "@stencil/core": "~2.10.0"
-      }
-    },
-    "node_modules/ionicons/node_modules/@stencil/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
+        "@stencil/core": "^2.18.0"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -7924,12 +7899,12 @@
       "dev": true
     },
     "@ionic/core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.0.tgz",
-      "integrity": "sha512-3e5EJhDebK4pCiFREpNB95o2kBSAdhRb3eMsBDOCYWYuFlcZEOGOpiGx+kYF/klYVQnB45UXAmR8nCX1indmHQ==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.5.4.tgz",
+      "integrity": "sha512-RHXoFRXOQl5o0COxlFfSfgAK8HZvmZ5Kd/YAORNzTqbm0W/bicUmbJf/oVUpWRnOl+R8sgGBUpOnwhTHl9jTag==",
       "requires": {
-        "@stencil/core": "~2.11.0-0",
-        "ionicons": "^6.0.0",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.1.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -8204,9 +8179,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-/IubCWhVXCguyMUp/3zGrg3c882+RJNg/zpiKfyfJL3kRCOwe+/MD8OoAXVGdd+xAohZKIi1Ik+EHFlsptsjLg=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.2.tgz",
+      "integrity": "sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -8496,7 +8471,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -9138,11 +9114,6 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
-    },
-    "date-fns": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
-      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
     },
     "debug": {
       "version": "4.3.1",
@@ -10253,18 +10224,11 @@
       "dev": true
     },
     "ionicons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.0.tgz",
-      "integrity": "sha512-p83W1T8jZUlllHAjuIWaDQbI36OYqdrwcf8MhYbKW7+9rjGlCMP9+5OaR0W7tl0QfM004uAiy/zkc7HTpDNKgA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.1.3.tgz",
+      "integrity": "sha512-ptzz38dd/Yq+PgjhXegh7yhb/SLIk1bvL9vQDtLv1aoSc7alO6mX2DIMgcKYzt9vrNWkRu1f9Jr78zIFFyOXqw==",
       "requires": {
-        "@stencil/core": "~2.10.0"
-      },
-      "dependencies": {
-        "@stencil/core": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.10.0.tgz",
-          "integrity": "sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A=="
-        }
+        "@stencil/core": "^2.18.0"
       }
     },
     "is-accessor-descriptor": {
@@ -10725,7 +10689,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -11702,7 +11667,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -13084,7 +13050,8 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,10 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^6.0.0",
-    "date-fns": "^2.25.0"
+    "@ionic/core": "^6.5.4"
   },
   "devDependencies": {
-    "@stencil/core": "^2.9.0",
+    "@stencil/core": "^2.22.2",
     "@types/jest": "^26.0.24",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,10 +36,6 @@ export namespace Components {
     }
     interface ComponentDatetime {
     }
-    /**
-     * This component is useful for providing a top section in the component page
-     * to describe what the component is and link to the Component & API docs.
-     */
     interface ComponentDetails {
         "description": string;
         "url": string;
@@ -210,10 +206,6 @@ declare global {
         prototype: HTMLComponentDatetimeElement;
         new (): HTMLComponentDatetimeElement;
     };
-    /**
-     * This component is useful for providing a top section in the component page
-     * to describe what the component is and link to the Component & API docs.
-     */
     interface HTMLComponentDetailsElement extends Components.ComponentDetails, HTMLStencilElement {
     }
     var HTMLComponentDetailsElement: {
@@ -529,10 +521,6 @@ declare namespace LocalJSX {
     }
     interface ComponentDatetime {
     }
-    /**
-     * This component is useful for providing a top section in the component page
-     * to describe what the component is and link to the Component & API docs.
-     */
     interface ComponentDetails {
         "description"?: string;
         "url"?: string;
@@ -686,10 +674,6 @@ declare module "@stencil/core" {
             "component-chip": LocalJSX.ComponentChip & JSXBase.HTMLAttributes<HTMLComponentChipElement>;
             "component-content": LocalJSX.ComponentContent & JSXBase.HTMLAttributes<HTMLComponentContentElement>;
             "component-datetime": LocalJSX.ComponentDatetime & JSXBase.HTMLAttributes<HTMLComponentDatetimeElement>;
-            /**
-             * This component is useful for providing a top section in the component page
-             * to describe what the component is and link to the Component & API docs.
-             */
             "component-details": LocalJSX.ComponentDetails & JSXBase.HTMLAttributes<HTMLComponentDetailsElement>;
             "component-fab": LocalJSX.ComponentFab & JSXBase.HTMLAttributes<HTMLComponentFabElement>;
             "component-grid": LocalJSX.ComponentGrid & JSXBase.HTMLAttributes<HTMLComponentGridElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -36,6 +36,10 @@ export namespace Components {
     }
     interface ComponentDatetime {
     }
+    /**
+     * This component is useful for providing a top section in the component page
+     * to describe what the component is and link to the Component & API docs.
+     */
     interface ComponentDetails {
         "description": string;
         "url": string;
@@ -206,6 +210,10 @@ declare global {
         prototype: HTMLComponentDatetimeElement;
         new (): HTMLComponentDatetimeElement;
     };
+    /**
+     * This component is useful for providing a top section in the component page
+     * to describe what the component is and link to the Component & API docs.
+     */
     interface HTMLComponentDetailsElement extends Components.ComponentDetails, HTMLStencilElement {
     }
     var HTMLComponentDetailsElement: {
@@ -521,6 +529,10 @@ declare namespace LocalJSX {
     }
     interface ComponentDatetime {
     }
+    /**
+     * This component is useful for providing a top section in the component page
+     * to describe what the component is and link to the Component & API docs.
+     */
     interface ComponentDetails {
         "description"?: string;
         "url"?: string;
@@ -674,6 +686,10 @@ declare module "@stencil/core" {
             "component-chip": LocalJSX.ComponentChip & JSXBase.HTMLAttributes<HTMLComponentChipElement>;
             "component-content": LocalJSX.ComponentContent & JSXBase.HTMLAttributes<HTMLComponentContentElement>;
             "component-datetime": LocalJSX.ComponentDatetime & JSXBase.HTMLAttributes<HTMLComponentDatetimeElement>;
+            /**
+             * This component is useful for providing a top section in the component page
+             * to describe what the component is and link to the Component & API docs.
+             */
             "component-details": LocalJSX.ComponentDetails & JSXBase.HTMLAttributes<HTMLComponentDetailsElement>;
             "component-fab": LocalJSX.ComponentFab & JSXBase.HTMLAttributes<HTMLComponentFabElement>;
             "component-grid": LocalJSX.ComponentGrid & JSXBase.HTMLAttributes<HTMLComponentGridElement>;

--- a/src/components/component-details/component-details.tsx
+++ b/src/components/component-details/component-details.tsx
@@ -1,15 +1,16 @@
 import { Component, Prop, h } from '@stencil/core';
 import { _template_ } from '../_template_/_template_';
 
-/**
- * This component is useful for providing a top section in the component page
- * to describe what the component is and link to the Component & API docs.
- */
 @Component({
   tag: 'component-details',
   styleUrl: 'component-details.css'
 })
+/**
+ * This component is useful for providing a top section in the component page
+ * to describe what the component is and link to the Component & API docs.
+ */
 export class ComponentDetails {
+
   @Prop() description: string;
 
   @Prop() url: string;

--- a/src/components/component-details/component-details.tsx
+++ b/src/components/component-details/component-details.tsx
@@ -10,7 +10,6 @@ import { _template_ } from '../_template_/_template_';
  * to describe what the component is and link to the Component & API docs.
  */
 export class ComponentDetails {
-
   @Prop() description: string;
 
   @Prop() url: string;

--- a/src/components/datetime/datetime.tsx
+++ b/src/components/datetime/datetime.tsx
@@ -1,27 +1,12 @@
-import { Component, State, h } from '@stencil/core';
-import { format, parseISO } from 'date-fns';
-import { DatetimeCustomEvent } from '@ionic/core';
+import { Component, h } from '@stencil/core';
 
 @Component({
   tag: 'component-datetime',
   styleUrl: 'datetime.css'
 })
 export class Datetime {
-  @State() startDate: string = format(new Date(), 'PP');
-  @State() endDate: string = format(new Date(), 'PP');
-
-  private onStartChange = (ev: DatetimeCustomEvent) => {
-    const date = format(parseISO(ev.detail.value), 'PP');
-    this.startDate = date;
-  }
-
-  private onEndChange = (ev: DatetimeCustomEvent) => {
-    const date = format(parseISO(ev.detail.value), 'PP');
-    this.endDate = date;
-  }
 
   render() {
-    const { startDate, endDate } = this;
     const description = '<b>Datetime</b> presents a calendar interface and time wheel, making it easy for users to select dates and times. Datetimes are similar to the native input elements of <code>datetime-local</code>, however, Ionic\'s Datetime component makes it easy to display the date and time in the a preferred format, and manage the datetime values.';
     const url = 'datetime';
 
@@ -50,18 +35,18 @@ export class Datetime {
         <ion-list inset={true}>
           <ion-accordion-group>
             <ion-accordion value="start">
-              <ion-item slot="header">
+              <ion-item lines="inset" slot="header">
                 <ion-label>Starts</ion-label>
-                <ion-note slot="end">{startDate}</ion-note>
+                <ion-datetime-button slot="end" datetime="start-date"></ion-datetime-button>
               </ion-item>
-              <ion-datetime slot="content" presentation="date-time" onIonChange={this.onStartChange}></ion-datetime>
+              <ion-datetime id="start-date" slot="content" presentation="date"></ion-datetime>
             </ion-accordion>
             <ion-accordion value="end">
-              <ion-item slot="header">
+              <ion-item lines="inset" slot="header">
                 <ion-label>Ends</ion-label>
-                <ion-note slot="end">{endDate}</ion-note>
+                <ion-datetime-button slot="end" datetime="end-date"></ion-datetime-button>
               </ion-item>
-              <ion-datetime slot="content" presentation="date-time" onIonChange={this.onEndChange}></ion-datetime>
+              <ion-datetime id="end-date" slot="content" presentation="date"></ion-datetime>
             </ion-accordion>
           </ion-accordion-group>
           <ion-item>


### PR DESCRIPTION
- Updates to latest Ionic 6
- Updates to latest Stencil 2
- Replaces custom date-fns logic with `ion-datetime-button`
- Moved the component-details comment so that it was not picked up by the Stencil compiler

I made the changes in the same PR as the deps updates for the following reasons:

1. A bug fix in Ionic uncovered a bug in the datetime page with lines not appearing correctly in items
2. A bug fix/feature in Stencil caused some component comments to be included in the build.