### PR TITLE
chore(ci): build with node 18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [12]
+        node_version: [18]
         os: [windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
Updates CI to build with a newer version of Node. Upcoming versions of Stencil will require Node 14 at a minimum.