### PR TITLE
chore: remove dynamic font scaling opt-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^7.6.2-dev.11704998705.1e1f9850"
+        "@ionic/core": "^7.7.2-dev.11707425083.192d8103"
       },
       "devDependencies": {
         "@stencil/core": "^2.22.2",
@@ -723,19 +723,19 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "7.6.2-dev.11704998705.1e1f9850",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.2-dev.11704998705.1e1f9850.tgz",
-      "integrity": "sha512-/Vdrgyq8aFr68KaNrChuejCUGppj+IbwR1CmZm9/S0+w12mtCyVM5+6VVq9CLAVi0YG7m2AK2S5ENtK+hv4Ljw==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2.tgz",
+      "integrity": "sha512-cH92OSqJBTaW8AAqh+M6NjzltVoAZCXqsHAOQMmZgrY4KgXNU+Wh+fs2La/UrFxTob9pZf30EpRddUG5rQYIFw==",
       "dependencies": {
-        "@stencil/core": "^4.8.2",
-        "ionicons": "^7.2.1",
+        "@stencil/core": "^4.12.2",
+        "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/core/node_modules/@stencil/core": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.10.0.tgz",
-      "integrity": "sha512-7lDTPY1IxXN2/C+wQPHt3e/dYgY4YgelA8MxOsU3ZftXtpzWad/QNWhSAtKisJMrSjQh41jMDOgD0yLBwV6E7w==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.2.tgz",
+      "integrity": "sha512-WEMpoqwMV4hY/ab2z9NxRhSeZwuKEugjyn6Vd+qA9xqZh6VNUL27QbP8vCa7IeqD4Zql4JBtKu3lVuBHutWE6w==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^7.7.2-dev.11707425083.192d8103"
+        "@ionic/core": "^7.7.2-dev.11707932366.16baf005"
       },
       "devDependencies": {
         "@stencil/core": "^2.22.2",
@@ -723,11 +723,11 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2.tgz",
-      "integrity": "sha512-cH92OSqJBTaW8AAqh+M6NjzltVoAZCXqsHAOQMmZgrY4KgXNU+Wh+fs2La/UrFxTob9pZf30EpRddUG5rQYIFw==",
+      "version": "7.7.2-dev.11707932366.16baf005",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.7.2-dev.11707932366.16baf005.tgz",
+      "integrity": "sha512-dZxVECHQ3MKn0ZzUrzRb/O2uG42iEH9ghdd8WfPqxCSKPs4hVbiIuZgu7BilUp2ad322+1k0Nh1ZA8BIjqoT6Q==",
       "dependencies": {
-        "@stencil/core": "^4.12.2",
+        "@stencil/core": "^4.12.0",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^7.7.2-dev.11707425083.192d8103"
+    "@ionic/core": "^7.7.2-dev.11707932366.16baf005"
   },
   "devDependencies": {
     "@stencil/core": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^7.6.2-dev.11704998705.1e1f9850"
+    "@ionic/core": "^7.7.2-dev.11707425083.192d8103"
   },
   "devDependencies": {
     "@stencil/core": "^2.22.2",

--- a/src/global/app.css
+++ b/src/global/app.css
@@ -50,11 +50,6 @@
   font-weight: 450 500;
 }
 
-/* Enable dynamic font scaling */
-html {
-  --ion-dynamic-font: var(--ion-default-dynamic-font);
-}
-
 .component-content {
   --background: var(--ion-color-step-50, #f2f2f7);
 }


### PR DESCRIPTION
Removes the dynamic font opt-in. This is built-in behavior in v8. 