### PR TITLE
fix: migrate to new step colors

### DIFF
--- a/src/components/app-home/app-home.css
+++ b/src/components/app-home/app-home.css
@@ -63,7 +63,7 @@
 }
 
 .component-icon-dark {
-  background: var(--ion-color-step-850, #27323e);
+  background: var(--ion-background-color-step-850, #27323e);
   color: var(--ion-item-background, #fff);
 }
 

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -3,14 +3,14 @@
 }
 
 component-card {
-  --background-darker: var(--ion-color-step-200, #e9edf3);
+  --background-darker: var(--ion-background-color-step-200, #e9edf3);
 
-  --text-dark: var(--ion-color-step-850, #27323f);
-  --text-darker: var(--ion-color-step-950, #0e151f);
+  --text-dark: var(--ion-text-color-step-150, #27323f);
+  --text-darker: var(--ion-text-color-step-50, #0e151f);
 
-  --text-light: var(--ion-color-step-650, #5b708b);
-  --text-lighter: var(--ion-color-step-550, #73849a);
-  --text-lightest: var(--ion-color-step-300, #b2becd);
+  --text-light: var(--ion-text-color-step-350, #5b708b);
+  --text-lighter: var(--ion-text-color-step-450, #73849a);
+  --text-lightest: var(--ion-text-color-step-700, #b2becd);
 }
 
 component-card ion-card .header-img {

--- a/src/components/component-details/component-details.css
+++ b/src/components/component-details/component-details.css
@@ -4,7 +4,7 @@ component-details ion-list {
 }
 
 component-details .item .component-description {
- color: var(--ion-color-step-800, #3e4a58);
+ color: var(--ion-text-color-step-200, #3e4a58);
  font-size: 1.125rem;
  line-height: 1.4;
  white-space: normal;

--- a/src/components/icons/icons.css
+++ b/src/components/icons/icons.css
@@ -2,5 +2,5 @@ component-icons ion-icon {
   font-size: 2.25rem;
   margin: 3px;
 
-  color: var(--ion-color-step-650, #444);
+  color: var(--ion-text-color-step-350, #444);
 }

--- a/src/components/nav/nav.css
+++ b/src/components/nav/nav.css
@@ -7,5 +7,5 @@ component-nav p:last-of-type {
 }
 
 component-nav p {
-  color: var(--ion-color-step-800, #3e4a58);
+  color: var(--ion-text-color-step-200, #3e4a58);
 }

--- a/src/global/app.css
+++ b/src/global/app.css
@@ -51,7 +51,7 @@
 }
 
 .component-content {
-  --background: var(--ion-color-step-50, #f2f2f7);
+  --background: var(--ion-background-color-step-50, #f2f2f7);
 }
 
 /*


### PR DESCRIPTION
When adopting the new theme stylesheets we did not migrate our step colors to use the separate text/background step colors. As a result, some colors in dark mode were incorrect.

To preview, got to https://docs-demo-git-migrate-step-colors-ionic1.vercel.app, enable dark mode, then open the Card page. You can compare with https://docs-demo.ionic.io to see how it looks right now.