### PR TITLE
fix: migrate to new picker

### DIFF
--- a/src/components/picker/picker.css
+++ b/src/components/picker/picker.css
@@ -1,0 +1,9 @@
+ion-modal {
+  --height: auto;
+
+  align-items: end;
+}
+
+ion-modal ion-picker {
+  margin-bottom: var(--ion-safe-area-bottom);
+}

--- a/src/components/picker/picker.tsx
+++ b/src/components/picker/picker.tsx
@@ -1,7 +1,5 @@
 import { Component, Element, h } from '@stencil/core';
 
-import { pickerController } from '@ionic/core';
-
 @Component({
   tag: 'component-picker',
   styleUrl: 'picker.css'
@@ -36,54 +34,12 @@ export class Picker {
     ]
   ]
 
-  async openPicker(numColumns = 1, numOptions = 5, columnOptions = this.defaultColumnOptions) {
-    const picker = await pickerController.create({
-      columns: this.getColumns(numColumns, numOptions, columnOptions),
-      buttons: [
-        {
-          text: 'Cancel',
-          role: 'cancel'
-        },
-        {
-          text: 'Confirm',
-          handler: (value) => {
-            console.log(`Got Value ${value}`);
-          }
-        }
-      ]
-    });
-
-    await picker.present();
-  }
-
-  getColumns(numColumns, numOptions, columnOptions) {
-    const columns = [];
-    for (let i = 0; i < numColumns; i++) {
-      columns.push({
-        name: `col-${i}`,
-        options: this.getColumnOptions(i, numOptions, columnOptions)
-      });
-    }
-
-    return columns;
-  }
-
-  getColumnOptions(columnIndex, numOptions, columnOptions) {
-    const options = [];
-    for (let i = 0; i < numOptions; i++) {
-      options.push({
-        text: columnOptions[columnIndex][i % numOptions],
-        value: i
-      })
-    }
-
-    return options;
+  dismissOverlay() {
+    document.querySelector('ion-modal').dismiss();
   }
 
   render() {
-    const description = `The <b>Picker</b> is a dialog that displays a row of buttons
-      and columns underneath. It appears on top of the app's content, and at the bottom
-      of the viewport.`;
+    const description = 'The <b>Picker</b> is a dialog that displays columns with options in each column. It appears inline with your page content, but it can also be displayed over your content by using a Modal or a Popover.';
     const url = 'picker';
 
     return [
@@ -100,8 +56,46 @@ export class Picker {
         <component-details description={description} url={url}></component-details>
 
         <div class="ion-padding-start ion-padding-end">
-          <ion-button class="ion-text-wrap" expand="block" onClick={_ => this.openPicker()}>Open Single Column Picker</ion-button>
-          <ion-button class="ion-text-wrap" expand="block" onClick={_ => this.openPicker(2, 5, this.multiColumnOptions)}>Open Multiple Column Picker</ion-button>
+
+          <ion-picker>
+            { this.defaultColumnOptions.map((c) => {
+              return (
+                <ion-picker-column value={c[0]}>
+                  { c.map((o) => {
+                    return (
+                      <ion-picker-column-option value={o}>{o}</ion-picker-column-option>
+                    )
+                  })}
+                </ion-picker-column>
+              )
+            })}
+          </ion-picker>
+
+          <ion-button id="open-picker" class="ion-text-wrap" expand="block">Open Picker in a Modal</ion-button>
+
+          <ion-modal trigger="open-picker">
+            <ion-toolbar>
+              <ion-buttons slot="start">
+                <ion-button onClick={() => this.dismissOverlay()}>Cancel</ion-button>
+              </ion-buttons>
+              <ion-buttons slot="end">
+                <ion-button onClick={() => this.dismissOverlay()}>Done</ion-button>
+              </ion-buttons>
+            </ion-toolbar>
+            <ion-picker>
+              { this.multiColumnOptions.map((c) => {
+                return (
+                  <ion-picker-column value={c[0]}>
+                    { c.map((o) => {
+                      return (
+                        <ion-picker-column-option value={o}>{o}</ion-picker-column-option>
+                      )
+                    })}
+                  </ion-picker-column>
+                )
+              })}
+            </ion-picker>
+          </ion-modal>
         </div>
       </ion-content>
     ];


### PR DESCRIPTION
This PR migrates the picker demo to use the new inline picker. It also shows a demo of the picker working in a modal. I updated the text on the picker page to more accurately reflect the default behavior of the new picker.

Preview: https://docs-demo-git-migrate-picker-ionic1.vercel.app/component/picker