### PR TITLE
fix: apply dark palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^8.0.0-beta.0"
+        "@ionic/core": "^8.0.0-beta.3"
       },
       "devDependencies": {
         "@stencil/core": "^2.22.2",
@@ -723,9 +723,9 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "8.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-beta.0.tgz",
-      "integrity": "sha512-d40s6NJRslSz8kJ4ONXpO1oxEPG0iF5dFf0ME862mEOna1gQnkrF8JBK26TlrlyoLXZkeptsF4BphVqYDh8zHw==",
+      "version": "8.0.0-dev.11711498366.18f063ac",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-dev.11711498366.18f063ac.tgz",
+      "integrity": "sha512-gTs39h2GiRjR8yx8LF6IpihFM5QikvKZkKD3yjQTrhra4MrkP6VpVA0upfZMvEyoNFX9ghdz9LxCLIt9818T9A==",
       "dependencies": {
         "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^8.0.0-beta.0"
+    "@ionic/core": "^8.0.0-beta.3"
   },
   "devDependencies": {
     "@stencil/core": "^2.22.2",

--- a/src/components/app-home/app-home.tsx
+++ b/src/components/app-home/app-home.tsx
@@ -9,7 +9,7 @@ export class AppHome {
   components = getComponents();
 
   toggleDarkMode = () => {
-    document.documentElement.classList.toggle('ion-theme-dark');
+    document.documentElement.classList.toggle('ion-palette-dark');
   }
 
   render() {

--- a/src/global/app.css
+++ b/src/global/app.css
@@ -31,7 +31,7 @@
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-@import "~@ionic/core/css/themes/dark.class.css";
+@import "~@ionic/core/css/palettes/dark.class.css";
 
 /*
  * Global CSS
@@ -60,7 +60,8 @@
  * https://bugs.webkit.org/show_bug.cgi?id=168418
  */
 
-_::-webkit-full-page-media, _:future ion-header .header-background,
+_::-webkit-full-page-media,
+_:future ion-header .header-background,
 :root .safari_only ion-header .header-background {
   backdrop-filter: none !important;
 }


### PR DESCRIPTION
Updates to the latest v8 beta and corrects the path update for `themes` → `palettes`. 