### PR TITLE
feat: button and input ionic theme examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^8.0.0-beta.0"
+        "@ionic/core": "^8.0.0-beta.3"
       },
       "devDependencies": {
         "@stencil/core": "^2.22.2",
@@ -723,9 +723,9 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "8.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-beta.0.tgz",
-      "integrity": "sha512-d40s6NJRslSz8kJ4ONXpO1oxEPG0iF5dFf0ME862mEOna1gQnkrF8JBK26TlrlyoLXZkeptsF4BphVqYDh8zHw==",
+      "version": "8.0.0-dev.11711498366.18f063ac",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.0.0-dev.11711498366.18f063ac.tgz",
+      "integrity": "sha512-gTs39h2GiRjR8yx8LF6IpihFM5QikvKZkKD3yjQTrhra4MrkP6VpVA0upfZMvEyoNFX9ghdz9LxCLIt9818T9A==",
       "dependencies": {
         "@stencil/core": "^4.12.2",
         "ionicons": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "^8.0.0-beta.3"
+        "@ionic/core": "^8.0.0-dev.11711498366.18f063ac"
       },
       "devDependencies": {
         "@stencil/core": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^8.0.0-beta.0"
+    "@ionic/core": "^8.0.0-beta.3"
   },
   "devDependencies": {
     "@stencil/core": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@ionic/core": "^8.0.0-beta.3"
+    "@ionic/core": "^8.0.0-dev.11711498366.18f063ac"
   },
   "devDependencies": {
     "@stencil/core": "^2.22.2",

--- a/src/components/app-home/app-home.tsx
+++ b/src/components/app-home/app-home.tsx
@@ -9,6 +9,7 @@ export class AppHome implements ComponentInterface {
   components = getComponents();
 
   private theme: string;
+  private themeToggleRef?: HTMLIonToggleElement;
 
   connectedCallback(): void {
     const config = JSON.parse(window.sessionStorage.getItem('ionic-persist-config')) ?? {};
@@ -34,9 +35,11 @@ export class AppHome implements ComponentInterface {
         theme: 'ionic'
       }));
     }
-    const confirm = window.confirm('Please reload the page for the changes to take effect.');
+    const confirm = window.confirm('This page will be reloaded to apply your changes.');
     if (confirm) {
       window.location.reload();
+    } else {
+      this.themeToggleRef.checked = false;
     }
   }
 
@@ -64,7 +67,7 @@ export class AppHome implements ComponentInterface {
           </ion-item>
           <ion-item>
             <ion-icon slot="start" icon="logo-ionic" class="component-icon component-icon-dark"></ion-icon>
-            <ion-toggle onIonChange={this.toggleIonicTheme} checked={this.theme === 'ionic'}>
+            <ion-toggle ref={ref => (this.themeToggleRef = ref)} onIonChange={this.toggleIonicTheme} checked={this.theme === 'ionic'}>
               Ionic Theme
             </ion-toggle>
           </ion-item>

--- a/src/components/app-home/app-home.tsx
+++ b/src/components/app-home/app-home.tsx
@@ -1,15 +1,43 @@
-import { Component, h } from '@stencil/core';
+import { Component, ComponentInterface, h } from '@stencil/core';
 import { getComponents } from '../../utils/component-utils';
 
 @Component({
   tag: 'app-home',
   styleUrl: 'app-home.css'
 })
-export class AppHome {
+export class AppHome implements ComponentInterface {
   components = getComponents();
+
+  private theme: string;
+
+  connectedCallback(): void {
+    const config = JSON.parse(window.sessionStorage.getItem('ionic-persist-config')) ?? {};
+    this.theme = config.theme;
+  }
 
   toggleDarkMode = () => {
     document.documentElement.classList.toggle('ion-palette-dark');
+  }
+
+  /**
+   * Changes the theme to the Ionic theme.
+   * Prompts the user to reload the page for the changes to take effect.
+   */
+  toggleIonicTheme = () => {
+    const config = JSON.parse(window.sessionStorage.getItem('ionic-persist-config')) ?? {};
+
+    if (config.theme === 'ionic') {
+      window.sessionStorage.removeItem('ionic-persist-config');
+    } else {
+      window.sessionStorage.setItem('ionic-persist-config', JSON.stringify({
+        ...config,
+        theme: 'ionic'
+      }));
+    }
+    const confirm = window.confirm('Please reload the page for the changes to take effect.');
+    if (confirm) {
+      window.location.reload();
+    }
   }
 
   render() {
@@ -34,7 +62,14 @@ export class AppHome {
               Dark Mode
             </ion-toggle>
           </ion-item>
+          <ion-item>
+            <ion-icon slot="start" icon="logo-ionic" class="component-icon component-icon-dark"></ion-icon>
+            <ion-toggle onIonChange={this.toggleIonicTheme} checked={this.theme === 'ionic'}>
+              Ionic Theme
+            </ion-toggle>
+          </ion-item>
         </ion-list>
+
 
         <ion-list class="home-list">
           {this.components.map(component => {

--- a/src/components/app-home/app-home.tsx
+++ b/src/components/app-home/app-home.tsx
@@ -9,7 +9,7 @@ export class AppHome {
   components = getComponents();
 
   toggleDarkMode = () => {
-    document.documentElement.classList.toggle('ion-theme-dark');
+    document.documentElement.classList.toggle('ion-palette-dark');
   }
 
   render() {

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -10,7 +10,7 @@ component-button section {
 
 component-button section .content {
   display: flex;
-  gap: 8px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -7,3 +7,14 @@ component-button section {
 
   padding: 0 10px;
 }
+
+component-button section .content {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+component-button section .content ion-button {
+  /* Prevent the button from stretching */
+  align-self: start;
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -115,7 +115,7 @@ export class Button {
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
             <ion-button theme="ionic" fill="clear" class="ion-focused">
-              Clear - Outline
+              Focused - Outline
             </ion-button>
             <ion-button theme="ionic" fill="clear" class="ion-focused">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -17,37 +17,67 @@ export class Button {
       </ion-header>,
 
       <ion-content fullscreen={true}>
+
         <section>
           <ion-list-header>
             <ion-label>
-              Small Size
+              Colors
             </ion-label>
           </ion-list-header>
-          <ion-button size="small">Default</ion-button>
-          <ion-button size="small" color="secondary">Secondary</ion-button>
-          <ion-button size="small" color="tertiary">Tertiary</ion-button>
+          <div class="content">
+            <ion-button color="success">Success</ion-button>
+            <ion-button color="warning">Warning</ion-button>
+            <ion-button color="danger">Danger</ion-button>
+            <ion-button color="secondary">Secondary</ion-button>
+            <ion-button color="tertiary">Tertiary</ion-button>
+            <ion-button color="light">Light</ion-button>
+            <ion-button color="medium">Medium</ion-button>
+            <ion-button color="dark">Dark</ion-button>
+          </div>
         </section>
 
         <section>
           <ion-list-header>
             <ion-label>
-              Default Size
+              Sizes
             </ion-label>
           </ion-list-header>
-          <ion-button color="success">Success</ion-button>
-          <ion-button color="warning">Warning</ion-button>
-          <ion-button color="danger">Danger</ion-button>
+          <div class="content">
+            <ion-button size="small">Small</ion-button>
+            <ion-button>Default</ion-button>
+            <ion-button size="large">Large</ion-button>
+            <ion-button size="xlarge">XLarge</ion-button>
+          </div>
         </section>
 
         <section>
           <ion-list-header>
             <ion-label>
-              Large Size
+             Shapes
             </ion-label>
           </ion-list-header>
-          <ion-button size="large" color="light">Light</ion-button>
-          <ion-button size="large" color="medium">Medium</ion-button>
-          <ion-button size="large" color="dark">Dark</ion-button>
+          <div class="content">
+            <ion-button>Default</ion-button>
+            <ion-button shape="round">Round</ion-button>
+            <ion-button shape="rectangular">Rectangular</ion-button>
+            <ion-button shape="round">
+              <ion-icon slot="icon-only" icon="heart"></ion-icon>
+            </ion-button>
+          </div>
+        </section>
+
+        <section>
+          <ion-list-header>
+            <ion-label>
+             Fills
+            </ion-label>
+          </ion-list-header>
+          <div class="content">
+            <ion-button>Default</ion-button>
+            <ion-button fill="outline">Outline</ion-button>
+            <ion-button fill="solid">Solid</ion-button>
+            <ion-button fill="clear">Clear</ion-button>
+          </div>
         </section>
 
         <section>

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,8 +1,8 @@
-import { Component, h } from '@stencil/core';
+import { Component, h } from "@stencil/core";
 
 @Component({
-  tag: 'component-button',
-  styleUrl: 'button.css'
+  tag: "component-button",
+  styleUrl: "button.css",
 })
 export class Button {
   render() {
@@ -17,12 +17,9 @@ export class Button {
       </ion-header>,
 
       <ion-content fullscreen={true}>
-
         <section>
           <ion-list-header>
-            <ion-label>
-              Colors
-            </ion-label>
+            <ion-label>Colors</ion-label>
           </ion-list-header>
           <div class="content">
             <ion-button color="success">Success</ion-button>
@@ -38,9 +35,7 @@ export class Button {
 
         <section>
           <ion-list-header>
-            <ion-label>
-              Sizes
-            </ion-label>
+            <ion-label>Sizes</ion-label>
           </ion-list-header>
           <div class="content">
             <ion-button size="small">Small</ion-button>
@@ -52,9 +47,7 @@ export class Button {
 
         <section>
           <ion-list-header>
-            <ion-label>
-             Shapes
-            </ion-label>
+            <ion-label>Shapes</ion-label>
           </ion-list-header>
           <div class="content">
             <ion-button>Default</ion-button>
@@ -68,9 +61,7 @@ export class Button {
 
         <section>
           <ion-list-header>
-            <ion-label>
-             Fills
-            </ion-label>
+            <ion-label>Fills</ion-label>
           </ion-list-header>
           <div class="content">
             <ion-button>Default</ion-button>
@@ -82,22 +73,100 @@ export class Button {
 
         <section>
           <ion-list-header>
-            <ion-label>
-              Block Width
-            </ion-label>
+            <ion-label>States - Activated</ion-label>
           </ion-list-header>
-          <ion-button class="ion-text-wrap" expand="block">A block button</ion-button>
+          <div class="content">
+            <ion-button theme="ionic" class="ion-activated">
+              Activated - Solid
+            </ion-button>
+            <ion-button theme="ionic" class="ion-activated">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" class="ion-activated">
+              Activated - Outline
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" class="ion-activated">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" class="ion-activated">
+              Activated - Clear
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" class="ion-activated">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+          </div>
         </section>
 
         <section>
           <ion-list-header>
-            <ion-label>
-              Full Width
-            </ion-label>
+            <ion-label>States - Focused</ion-label>
           </ion-list-header>
-          <ion-button class="ion-text-wrap" expand="full" color="secondary">A full-width button</ion-button>
+          <div class="content">
+            <ion-button theme="ionic" class="ion-focused">
+              Focuseded
+            </ion-button>
+            <ion-button theme="ionic" class="ion-focused">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" class="ion-focused">
+              Focused - Outline
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" class="ion-focused">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" class="ion-focused">
+              Clear - Outline
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" class="ion-focused">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+          </div>
         </section>
-      </ion-content>
+
+        <section>
+          <ion-list-header>
+            <ion-label>States - Disabled</ion-label>
+          </ion-list-header>
+          <div class="content">
+            <ion-button theme="ionic" disabled="true">
+              Disabled
+            </ion-button>
+            <ion-button theme="ionic" disabled="true">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" disabled="true">
+              Disabled - Outline
+            </ion-button>
+            <ion-button theme="ionic" fill="outline" disabled="true">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" disabled="true">
+              Disabled - Clear
+            </ion-button>
+            <ion-button theme="ionic" fill="clear" disabled="true">
+              <ion-icon slot="icon-only" name="rocket"></ion-icon>
+            </ion-button>
+          </div>
+        </section>
+
+        <section>
+          <ion-list-header>
+            <ion-label>Block Width</ion-label>
+          </ion-list-header>
+          <ion-button class="ion-text-wrap" expand="block">
+            A block button
+          </ion-button>
+        </section>
+
+        <section>
+          <ion-list-header>
+            <ion-label>Full Width</ion-label>
+          </ion-list-header>
+          <ion-button class="ion-text-wrap" expand="full" color="secondary">
+            A full-width button
+          </ion-button>
+        </section>
+      </ion-content>,
     ];
   }
 }

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,11 +1,15 @@
-import { Component, h } from "@stencil/core";
+import { Component, h } from '@stencil/core';
 
 @Component({
-  tag: "component-button",
-  styleUrl: "button.css",
+  tag: 'component-button',
+  styleUrl: 'button.css',
 })
 export class Button {
   render() {
+    const config = JSON.parse(
+      window.sessionStorage.getItem('ionic-persist-config')
+    );
+
     return [
       <ion-header translucent={true}>
         <ion-toolbar>
@@ -41,7 +45,9 @@ export class Button {
             <ion-button size="small">Small</ion-button>
             <ion-button>Default</ion-button>
             <ion-button size="large">Large</ion-button>
-            <ion-button size="xlarge">XLarge</ion-button>
+            {config.theme === 'ionic' && (
+              <ion-button size="xlarge">XLarge</ion-button>
+            )}
           </div>
         </section>
 
@@ -76,22 +82,20 @@ export class Button {
             <ion-label>States - Activated</ion-label>
           </ion-list-header>
           <div class="content">
-            <ion-button theme="ionic" class="ion-activated">
-              Activated - Solid
-            </ion-button>
-            <ion-button theme="ionic" class="ion-activated">
+            <ion-button class="ion-activated">Activated - Solid</ion-button>
+            <ion-button class="ion-activated">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="outline" class="ion-activated">
+            <ion-button fill="outline" class="ion-activated">
               Activated - Outline
             </ion-button>
-            <ion-button theme="ionic" fill="outline" class="ion-activated">
+            <ion-button fill="outline" class="ion-activated">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="clear" class="ion-activated">
+            <ion-button fill="clear" class="ion-activated">
               Activated - Clear
             </ion-button>
-            <ion-button theme="ionic" fill="clear" class="ion-activated">
+            <ion-button fill="clear" class="ion-activated">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
           </div>
@@ -102,22 +106,20 @@ export class Button {
             <ion-label>States - Focused</ion-label>
           </ion-list-header>
           <div class="content">
-            <ion-button theme="ionic" class="ion-focused">
-              Focuseded
-            </ion-button>
-            <ion-button theme="ionic" class="ion-focused">
+            <ion-button class="ion-focused">Focused</ion-button>
+            <ion-button class="ion-focused">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="outline" class="ion-focused">
+            <ion-button fill="outline" class="ion-focused">
               Focused - Outline
             </ion-button>
-            <ion-button theme="ionic" fill="outline" class="ion-focused">
+            <ion-button fill="outline" class="ion-focused">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="clear" class="ion-focused">
-              Focused - Outline
+            <ion-button fill="clear" class="ion-focused">
+              Focused - Clear
             </ion-button>
-            <ion-button theme="ionic" fill="clear" class="ion-focused">
+            <ion-button fill="clear" class="ion-focused">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
           </div>
@@ -128,22 +130,20 @@ export class Button {
             <ion-label>States - Disabled</ion-label>
           </ion-list-header>
           <div class="content">
-            <ion-button theme="ionic" disabled="true">
-              Disabled
-            </ion-button>
-            <ion-button theme="ionic" disabled="true">
+            <ion-button disabled="true">Disabled</ion-button>
+            <ion-button disabled="true">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="outline" disabled="true">
+            <ion-button fill="outline" disabled="true">
               Disabled - Outline
             </ion-button>
-            <ion-button theme="ionic" fill="outline" disabled="true">
+            <ion-button fill="outline" disabled="true">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
-            <ion-button theme="ionic" fill="clear" disabled="true">
+            <ion-button fill="clear" disabled="true">
               Disabled - Clear
             </ion-button>
-            <ion-button theme="ionic" fill="clear" disabled="true">
+            <ion-button fill="clear" disabled="true">
               <ion-icon slot="icon-only" name="rocket"></ion-icon>
             </ion-button>
           </div>

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -51,6 +51,12 @@ export class Input {
             </ion-item>
 
             <ion-item>
+              <ion-input label="Password" label-placement="stacked" type="password">
+                <ion-input-password-toggle slot="end"></ion-input-password-toggle>
+              </ion-input>
+            </ion-item>
+
+            <ion-item>
               <ion-label position="stacked">Address</ion-label>
               <ion-input aria-label="Address Line 1" placeholder="Address Line 1"></ion-input>
               <ion-input aria-label="Address Line 2" placeholder="Address Line 2"></ion-input>

--- a/src/global/app.css
+++ b/src/global/app.css
@@ -31,7 +31,7 @@
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-@import "~@ionic/core/css/themes/dark.class.css";
+@import "~@ionic/core/css/palettes/dark.class.css";
 
 /*
  * Global CSS
@@ -60,7 +60,8 @@
  * https://bugs.webkit.org/show_bug.cgi?id=168418
  */
 
-_::-webkit-full-page-media, _:future ion-header .header-background,
+_::-webkit-full-page-media,
+_:future ion-header .header-background,
 :root .safari_only ion-header .header-background {
   backdrop-filter: none !important;
 }


### PR DESCRIPTION
- Updates the docs demo to use a temporary dev-build
- Adds the ability to enable the ionic theme. This toggle is intended for an audience not familiar with the query parameter syntax
- Adds button examples
- Adds input password toggle example